### PR TITLE
Fixed TypeError during csv export

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -19,8 +19,12 @@ function csvDL(rows, name) {
     csv +=
       cols
         .map((k) => {
-          const v = r[k] || '';
-          return v.includes(';') ? `"${v}"` : v;
+          const raw = r[k];
+          const s = raw == null ? '' : String(raw);
+          const escaped = s.replace(/"/g, '""');
+          const needsQuotes = /[;\n\r"]/.test(escaped);
+
+          return needsQuotes ? `"${escaped}"` : escaped;
         })
         .join(';') + '\n';
   });


### PR DESCRIPTION
While running the codebase locally and trying to export the csv from a PDF I encountered this error:
<img width="1867" height="120" alt="Schermata del 2026-02-27 13-49-46" src="https://github.com/user-attachments/assets/fa2d6f91-2f27-4e42-a936-49c872e42e5d" />
The changes should take care of possible type mismatches and properly escape quotes.